### PR TITLE
Sybil attack mitagation

### DIFF
--- a/src/common/I2P/IDs/Destination.java
+++ b/src/common/I2P/IDs/Destination.java
@@ -49,8 +49,6 @@ public class Destination implements JSONSerializable {
             MessageDigest md = MessageDigest.getInstance("SHA256");
             md.update(keys.getSigningPublicKey().getEncoded());
 
-            //take only first 3 bytes of hash(I2P spec uses 1 but we are using base64 encoding is 6 bit aligned
-            // So 3 bytes is the smallest we can have without padding bytes (24 bits divides evenly into 6)
             return md.digest();
 
         }

--- a/src/common/I2P/IDs/RouterID.java
+++ b/src/common/I2P/IDs/RouterID.java
@@ -3,13 +3,11 @@ package common.I2P.IDs;
 import merrimackutil.json.JSONSerializable;
 import merrimackutil.json.types.JSONObject;
 import merrimackutil.json.types.JSONType;
-import org.bouncycastle.util.encoders.Base64;
 
 import java.io.InvalidObjectException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
-import java.util.Arrays;
 
 /**
  * Class to uniquely identify router
@@ -57,8 +55,6 @@ public class RouterID implements JSONSerializable {
             md.update(keys.getPublicKey().getEncoded());
             md.update(keys.getSigningPublicKey().getEncoded());
 
-            //take only first 3 bytes of hash(I2P spec uses 1 but we are using base64 encoding is 6 bit aligned
-            // So 3 bytes is the smallest we can have without padding bytes (24 bits divides evenly into 6)
             return md.digest();
 
         }

--- a/src/common/I2P/NetworkDB/NetDB.java
+++ b/src/common/I2P/NetworkDB/NetDB.java
@@ -3,6 +3,15 @@ package common.I2P.NetworkDB;
 import common.Logger;
 import org.bouncycastle.util.encoders.Base64;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 
 /**
@@ -13,25 +22,36 @@ public class NetDB {
      * Router Info for this router maintaining the netDB
      */
     private RouterInfo routerInfo;
+    private byte[] rootRoutingKey;
     /**
      * RoutingTable has 256 buckets(32 byte sha256 hash) each bucket has an entry keyed under a hash of that entry with
      * a corresponding record to that hash(RouterInfo or LeaseSet)
      */
     private HashMap<Integer, HashMap<String, Record>> routingTable;
     /**
-     *
+     * Logger for this branch
      */
     private Logger log = Logger.getInstance();
+    private String lastHour;
+
     /**
      * Create a new NetDB for this router {@code routerInfo}
      * @param routerInfo routerInfo
      */
     public NetDB(RouterInfo routerInfo) {
-        this.routerInfo = routerInfo;
         routingTable = new HashMap<>(); //create new routingTable we will use lazy initialization for each bucket
 
-        //we will store ourselfs in netDB in case someone wants to lookup us
-        store(routerInfo);
+        this.routerInfo = routerInfo;
+        //set hour off last key rotation
+        //chatGPT generated date formatting
+        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyyMMddHH");
+
+        lastHour = Instant.now()                // current moment
+                .truncatedTo(ChronoUnit.HOURS)  // drop mins/sec/nanos
+                .atZone(ZoneOffset.UTC)         // view in UTC
+                .format(fmt);                   // format as yyyyMMddHH
+
+        this.rootRoutingKey = computeRoutingKey(routerInfo.getHash());
     }
 
     /**
@@ -43,12 +63,14 @@ public class NetDB {
             log.warn("NetDB: Record has Invalid signature disregarding");
             return;
         }
+        byte[] routingKey = computeRoutingKey(record.getHash());
+
         //avoid storing ourselfs so we do not get our own hash when getting k closest peers
-        if (Arrays.equals(record.getHash(),routerInfo.getHash()))
+        if (Arrays.equals(routingKey, rootRoutingKey))
             return;
 
         //calculate distance between hash and record hash
-        int distance = calculateXORMetric(routerInfo.getHash(), record.getHash());
+        int distance = calculateXORMetric(rootRoutingKey, routingKey);
 
         //get bucket at distance
         HashMap<String, Record> bucket = routingTable.get(distance);
@@ -59,10 +81,9 @@ public class NetDB {
             routingTable.put(distance, bucket);
         }
 
-        //add record to bucket under its key(hash of record)
-        // could actually just get key of record isntead of record.getHash() but no diff
-        bucket.put(Base64.toBase64String(record.getHash()), record);
-        log.debug("Put record into bucket " + distance + " hash " + Base64.toBase64String(record.getHash()));
+        //put record under routing key
+        bucket.put(Base64.toBase64String(routingKey), record);
+        log.debug("Put record into bucket " + distance + " hash " + Base64.toBase64String(routingKey));
         log.trace(logNetDB());
     }
 
@@ -72,11 +93,15 @@ public class NetDB {
      * @return Record {@code RouterInfo or LeaseSet} or null if record is not found
      */
     public synchronized Record lookup(byte[] key) {
+        //get routing key
+        byte[] routingKey = computeRoutingKey(key);
+
         if (Arrays.equals(key, routerInfo.getHash())) //we do not store ourselves so we handle that case here
             return routerInfo;
 
+
         //calculate distance between hash and record we want to find(under key)
-        int distance = calculateXORMetric(routerInfo.getHash(), key);
+        int distance = calculateXORMetric(rootRoutingKey, routingKey);
         log.trace("NetDB: distance is " + distance);
 
         //get bucket key would be stored in
@@ -86,7 +111,7 @@ public class NetDB {
             return null;
         //Attempt to find record in bucket(will return null if not found)
         log.trace(logNetDB());
-        return bucket.get(Base64.toBase64String(key));
+        return bucket.get(Base64.toBase64String(routingKey));
     }
 
     /**
@@ -102,7 +127,8 @@ public class NetDB {
      */
     public synchronized ArrayList<RouterInfo> getKClosestRouterInfos(byte[] key, int k) {
         // Calculate XOR distance from our own router ID to the target key
-        int startDistance = calculateXORMetric(routerInfo.getHash(), key);
+        byte[] routingKey = computeRoutingKey(key);
+        int startDistance = calculateXORMetric(rootRoutingKey, routingKey);
         //below is chatgpt generated but it did what i wanted for this kind of annoying bit of code
 
         ArrayList<RouterInfo> result = new ArrayList<>(k); // Prepare result list with initial capacity
@@ -164,8 +190,9 @@ public class NetDB {
      */
     public synchronized ArrayList<Record> getKClosestPeers(byte[] key, int k) {
         ArrayList<Record> result = new ArrayList<>(k);
+        byte[] routingKey = computeRoutingKey(key);
 
-        int startDistance = calculateXORMetric(routerInfo.getHash(), key);
+        int startDistance = calculateXORMetric(rootRoutingKey, routingKey);
         int lower  = startDistance;      // search downward
         int higher = startDistance + 1;  // and upward
 
@@ -198,8 +225,62 @@ public class NetDB {
         return result;
     }
 
+    /**
+     * Computer routing key H(H(record) + time up to hour UTC) this is to make Sybil attacks more expensive
+     * @param key of Record to compute routing key for
+     * @return Bytes of routing key
+     */
+    private synchronized byte[] computeRoutingKey(byte[] key) {
+        //add record to bucket under its RoutingKey which is the hash of the record with date up to hour appeneded
+        //this is to prevent a sybil attack by doing a partial rotation of the keyspace every hour(every day in I2P)
+        //chatGPT generated date formatting
+        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyyMMddHH");
 
+        String currHour = Instant.now()                // current moment
+                .truncatedTo(ChronoUnit.HOURS)  // drop mins/sec/nanos
+                .atZone(ZoneOffset.UTC)         // view in UTC
+                .format(fmt);                   // format as yyyyMMddHH
 
+        /* --- parse as UTC ZonedDateTime ---------------------------------------- */
+        ZonedDateTime prev = LocalDateTime.parse(lastHour, fmt).atZone(ZoneOffset.UTC);
+        ZonedDateTime curr = LocalDateTime.parse(currHour, fmt).atZone(ZoneOffset.UTC);
+
+        rootRoutingKey = computeHashOfKey(routerInfo.getHash(), currHour);
+        //rotate routing keys if it is a new hours
+        if (!curr.isBefore(prev.plusHours(1))) {
+            log.debug("Last hour: " + lastHour + " currHour: " + currHour);
+            log.info("Next hour, Rotating NetDB keys");
+
+            HashMap<Integer, HashMap<String, Record>> newRoutingTable = new HashMap<>();
+            for (HashMap<String, Record> bucket : routingTable.values()) {
+                for (Record record : bucket.values()) {
+                    byte[] routingKey = computeHashOfKey(key, currHour);
+                    //calculate distance between hash and record hash
+                    int distance = calculateXORMetric(rootRoutingKey, routingKey);
+
+                    //get bucket at distance
+                    HashMap<String, Record> newBucket = newRoutingTable.computeIfAbsent(distance, k -> new HashMap<>());
+                    newBucket.put(Base64.toBase64String(routingKey), record);
+                }
+            }
+            routingTable = newRoutingTable;
+            lastHour = currHour;
+            log.debug("new netDB " + logNetDB());
+        }
+
+        return computeHashOfKey(key, lastHour);
+    }
+
+    private byte[] computeHashOfKey(byte[] key, String time) {
+        try {
+            //hash payload of message
+            MessageDigest md = MessageDigest.getInstance("SHA256");
+            md.update(key);
+            md.update(time.getBytes(StandardCharsets.UTF_8));
+            return md.digest();
+        }
+        catch (NoSuchAlgorithmException ex) {throw new RuntimeException(ex);} //should not hit this case
+    }
 
     /**
      * Calculate closeness as from XOR metric of keys we xor keys, they are close if result have many leading zeroes -

--- a/src/common/I2P/NetworkDB/NetDB.java
+++ b/src/common/I2P/NetworkDB/NetDB.java
@@ -254,7 +254,7 @@ public class NetDB {
             HashMap<Integer, HashMap<String, Record>> newRoutingTable = new HashMap<>();
             for (HashMap<String, Record> bucket : routingTable.values()) {
                 for (Record record : bucket.values()) {
-                    byte[] routingKey = computeHashOfKey(key, currHour);
+                    byte[] routingKey = computeHashOfKey(record.getHash(), currHour);
                     //calculate distance between hash and record hash
                     int distance = calculateXORMetric(rootRoutingKey, routingKey);
 

--- a/src/common/I2P/NetworkDB/RouterInfo.java
+++ b/src/common/I2P/NetworkDB/RouterInfo.java
@@ -79,31 +79,9 @@ public class RouterInfo extends Record implements JSONSerializable {
         deserialize(json);
     }
 
-    /**
-     * Get SHA256 hash of this class
-     * @return 32 byte SHA256 hash of this class
-     */
+    @Override
     public byte[] getHash() {
-        try {
-            //hash this class
-            MessageDigest md = MessageDigest.getInstance("SHA256");
-            //update hash with router info
-            md.update(routerID.getElgamalPublicKey().getEncoded());
-            md.update(routerID.getSigningPublicKey().getEncoded());
-            //update hash with date
-            ByteBuffer longBytes = ByteBuffer.allocate(Long.BYTES);
-            longBytes.putLong(date);
-            md.update(longBytes);
-            //update hash with host
-            md.update(routerAddress.host.getBytes(StandardCharsets.UTF_8));
-            //update hash with port
-            ByteBuffer portByte = ByteBuffer.allocate(Integer.BYTES);
-            portByte.putInt(routerAddress.port);
-            md.update(portByte);
-
-            return md.digest();
-        }
-        catch (NoSuchAlgorithmException ex) {throw new RuntimeException(ex);} //should not hit this case
+        return routerID.getHash();
     }
 
     /**


### PR DESCRIPTION
We will rotate keys in netDB every hour to avoid Sybil style attacks to isolate a peer in the NetDB. Anyone launching a sybil attack will need to restart their attack every hour, this puts us in line with NetDB in I2P vs regular DHT in Kademelia 